### PR TITLE
Quiescence

### DIFF
--- a/src/willow.c
+++ b/src/willow.c
@@ -1712,6 +1712,8 @@ int quiesce(struct board_info *board, int alpha, int beta, int depth, int depthl
             int maxloss = (d*VALUES[piecetypefrom] + (MAXPHASE-d)*VALUES2[piecetypefrom])/MAXPHASE;
             int mingain = (d*VALUES[piecetypeto] + (MAXPHASE-d)*VALUES2[piecetypeto])/MAXPHASE;
 
+            //exit(0);
+
             if (stand_pat + mingain - maxloss >= beta){
                 CURRENTPOS = original_pos;
                 return stand_pat + mingain - maxloss;

--- a/src/willow.c
+++ b/src/willow.c
@@ -1675,7 +1675,7 @@ int quiesce(struct board_info *board, int alpha, int beta, int depth, int depthl
     }
 
 
-    if (movescore(board, list, 0, color, 'n', nullmove, listlen)){
+    if (movescore(board, list, 99, color, 'n', nullmove, listlen)){
         printfull(board);
         exit(1);
     }
@@ -1686,8 +1686,7 @@ int quiesce(struct board_info *board, int alpha, int beta, int depth, int depthl
 
     while (i < listlen){
         selectionsort(list, i, listlen);
-        
-        if ((!incheck) && list[i].eval < 1000200){
+        if ((!incheck) && (list[i].eval < 1000001 || (stand_pat < alpha && list[i].eval < 1000200))){
             CURRENTPOS = original_pos;
             return bestscore;
         }
@@ -1910,7 +1909,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
         }
         ismove = true;
         bool iscap = (list[i].move.flags == 0xC || board->board[list[i].move.move & 0xFF]);    
-            
+
         if (depth > 0 && !iscap && !ispv){
             if (depthleft < 4){
             numquiets++;
@@ -1919,7 +1918,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
             }
             }
 
-            if (depthleft < 6 && list[i].eval < 1000001 && movelst[*key-1].staticeval + 90*(depthleft) + (improving*40) < alpha){
+            if ((depthleft < 6 && list[i].eval < 1000001 && movelst[*key-1].staticeval + 90*(depthleft) + (improving*40) < alpha)){
                 quietsprune = true;
             }
 

--- a/src/willow.c
+++ b/src/willow.c
@@ -1704,8 +1704,8 @@ int quiesce(struct board_info *board, int alpha, int beta, int depth, int depthl
         }
         if (list[i].eval > 1000199 && (board->board[list[i].move.move>>8]>>1) < (board->board[list[i].move.move & 0xFF]>>1)){ 
             //all captures of a higher ranking piece are checked to see if they're just immediately good enough
-            int d; 
-            material(board, &d);
+            int d = 0; 
+            int a = material(board, &d);
 
             unsigned char piecetypefrom = (board->board[list[i].move.move>>8]>>1)-1, piecetypeto = (board->board[list[i].move.move & 0xFF]>>1)-1;
 


### PR DESCRIPTION
Added expected beta cutoffs in quiescent search.

ELO   | 10.60 +- 6.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5608 W: 1553 L: 1382 D: 2673