### PR TITLE
Clear killer info

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -262,7 +262,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
         }
     }
 
-    if (depthleft <= 0 || depth >= MAXDEPTH)     //if we're too deep drop into qsearch, adjusting based on depth if we get a mate score.
+    if (depthleft <= 0 || depth >= 99)     //if we're too deep drop into qsearch, adjusting based on depth if we get a mate score.
     {
         int b = quiesce(board, alpha, beta, depth, 15, color, incheck);
         if (b == -100000)


### PR DESCRIPTION
ELO   | 5.17 +- 4.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 14920 W: 3981 L: 3759 D: 7180
https://chess.swehosting.se/test/1901/