### PR TITLE
change see constants

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -448,7 +448,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
 
         // SEE pruning: if a quick check shows that we're hanging material, we skip the move.
         if (depth && list[i].eval < 1000200 && bestscore > -50000 && depthleft < 9 &&
-            !static_exchange_evaluation(board, list[i].move, color, depthleft * ((iscap || list[i].move.flags >> 2 == 1) ? -90 : -50)))
+            !static_exchange_evaluation(board, list[i].move, color, depthleft * (iscap ? -30 * depthleft : -80)))
         {
             CURRENTPOS = original_pos;
             nnue_state.pop();


### PR DESCRIPTION
ELO   | 6.65 +- 4.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9608 W: 2344 L: 2160 D: 5104
https://chess.swehosting.se/test/2932/