### PR TITLE
fake elo

### DIFF
--- a/src/willow.cpp
+++ b/src/willow.cpp
@@ -243,7 +243,12 @@ int com_uci(struct board_info *board, struct movelist *movelst, int *key, bool *
             }
 
             int milltime = atoi(&command[k]) - 50;
-            maximumtime = (float)milltime/5000;
+            if (movestogo > 2 || movestogo == -1){
+                maximumtime = (float)milltime/5000;
+            }
+            else{
+                maximumtime = (float)milltime/2000;
+            }
             if (milltime < 1)
             {
                 time = 0.001;
@@ -259,8 +264,8 @@ int com_uci(struct board_info *board, struct movelist *movelst, int *key, bool *
                 }
                 else
                 {
-                    int movesleft = MAX(20, 70 - (*key / 2));
-                    time = ((float)milltime / (1000 * movesleft)) * 1.5;
+                    int movesleft = 20;
+                    time = ((float)milltime / (1000 * movesleft));
                 }
 
                 if (strstr(command, "winc"))
@@ -301,7 +306,7 @@ int com_uci(struct board_info *board, struct movelist *movelst, int *key, bool *
                     milltime = atoi(&command[k]);
                     if (time + ((float)milltime / 1000 * 4) < coldturkey)
                     { // if you have at least four increments left over, it's safe to add half the increment to your move.
-                        time += (float)milltime / 1000 * 0.5;
+                        time += (float)milltime / 1000 * 0.75;
                     }
                 }
             }


### PR DESCRIPTION
ELO   | 25.15 +- 8.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 3488 W: 1124 L: 872 D: 1492
https://chess.swehosting.se/test/3035/