### PR TITLE
add the SE fix

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -469,7 +469,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
         if (depth && depth < info.depth * 2)
         { // if we're not already in a singular search, do singular search.
 
-            if (!singularsearch && depthleft >= 7 && list[i].eval == 11000000 && abs(evl) < 50000 && TT[(thread_info->CURRENTPOS & _mask)].depth >= depthleft - 3 && type != UBound)
+            if (!singularsearch && depthleft >= 7 && list[i].eval == 11000000 && abs(evl) < 50000 && entry.depth >= depthleft - 3 && type != UBound)
             {
                 int sBeta = ttscore - (depthleft);
 


### PR DESCRIPTION
ELO   | 1.84 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.28 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 69664 W: 17966 L: 17598 D: 34100
https://chess.swehosting.se/test/3763/