### PR TITLE
lmr caphist

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -542,10 +542,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
                 if (iscap && !ispv)
                 {
                     R = R / 2;
-                    if (list[i].eval > 1000190)
-                    {
-                        R--;
-                    }
+                    R -= thread_info->CAPHIST[color][list[i].move.move >> 8][list[i].move.move & 0xFF] / 8096;
                 }
                 if (ischeck) // Reduce reduction for checks or moves made in check
                 {


### PR DESCRIPTION
ELO   | 4.55 +- 3.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 22624 W: 5778 L: 5482 D: 11364
https://chess.swehosting.se/test/4430/