### PR TITLE
NMP change with evl >= staticeval

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -318,7 +318,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
     thread_info->KILLERTABLE[depth + 1][0] = nullmove;
     movelst[*key - 1].staticeval = evl;
 
-    bool improving = (depth > 1 && !incheck && movelst[*key - 1].staticeval > movelst[*key - 3].staticeval && movelst[*key-3].staticeval != -100000); 
+    bool improving = (depth > 1 && !incheck && movelst[*key - 1].staticeval > movelst[*key - 3].staticeval); 
         // Is our position better than it was during our last move?
 
     if (type == Exact || (type == UBound && ttscore < evl) || (type == LBound && ttscore > evl)) // Use the evaluation from the transposition table as it is more accurate than the static evaluation.
@@ -338,8 +338,8 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
     bool isnull = (depth > 0 && movelst[*key-1].piecetype == -1);
 
     // Null Move Pruning: If our position is good enough that we can give our opponent an extra move and still beat beta with a reduced search, cut off.
-    if (isnull == false && !ispv && !singularsearch && !incheck && depthleft > 2 && evl >= movelst[*key-1].staticeval &&
-        (evl >= beta + 50 - MIN(50, ((improving + 1) * depthleft * 5))))
+    if (isnull == false && !ispv && !singularsearch && !incheck && evl >= movelst[*key-1].staticeval &&
+        (evl >= beta + 30 * (depthleft < 4)))
     {
 
         bool ispiecew = false, ispieceb = false;

--- a/src/search.h
+++ b/src/search.h
@@ -318,7 +318,8 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
     thread_info->KILLERTABLE[depth + 1][0] = nullmove;
     movelst[*key - 1].staticeval = evl;
 
-    bool improving = (depth > 1 && !incheck && movelst[*key - 1].staticeval > movelst[*key - 3].staticeval); // Is our position better than it was during our last move?
+    bool improving = (depth > 1 && !incheck && movelst[*key - 1].staticeval > movelst[*key - 3].staticeval && movelst[*key-3].staticeval != -100000); 
+        // Is our position better than it was during our last move?
 
     if (type == Exact || (type == UBound && ttscore < evl) || (type == LBound && ttscore > evl)) // Use the evaluation from the transposition table as it is more accurate than the static evaluation.
     {
@@ -337,7 +338,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
     bool isnull = (depth > 0 && movelst[*key-1].piecetype == -1);
 
     // Null Move Pruning: If our position is good enough that we can give our opponent an extra move and still beat beta with a reduced search, cut off.
-    if (isnull == false && !ispv && !singularsearch && !incheck && depthleft > 2 &&
+    if (isnull == false && !ispv && !singularsearch && !incheck && depthleft > 2 && evl >= movelst[*key-1].staticeval &&
         (evl >= beta + 50 - MIN(50, ((improving + 1) * depthleft * 5))))
     {
 


### PR DESCRIPTION
ELO   | 3.78 +- 2.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 29728 W: 7702 L: 7379 D: 14647
https://chess.swehosting.se/test/4524/