### PR TITLE
skip bad captures in lmp/fp as well

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -408,12 +408,12 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
     bool quietsprune = false;
     int bestscore = -100000;
 
-    while (i < movelen)
+    while (i < movelen && !quietsprune)
     {
         // First, make sure the move is legal, not skipped by futility pruning or LMP, and that there's no errors making the move.
         selectionsort(list, i, movelen);
         bool iscap = (list[i].move.flags == 0xC || board->board[list[i].move.move & 0xFF] || list[i].move.flags == 0x7) && !(list[i].move.flags / 4 == 2);
-        if ((quietsprune && !iscap) || ismatch(excludedmove, list[i].move))
+        if (ismatch(excludedmove, list[i].move))
         {
             i++;
             continue;


### PR DESCRIPTION
ELO   | 2.87 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 46544 W: 12406 L: 12022 D: 22116
https://chess.swehosting.se/test/4726/