### PR TITLE
move scoring speed up

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -121,7 +121,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     struct list list[LISTSIZE];
     int listlen = movegen(board, list, color, incheck);
 
-    movescore(board, movelst, key, list, 99, color, type, listlen, -108, thread_info, entry);
+    movescore(board, movelst, key, list, 99, color, type, listlen, -108, thread_info, entry, incheck);
     // score the moves
 
     struct move bestmove = nullmove;
@@ -398,7 +398,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
     int i = 0;
     unsigned long long int original_pos = thread_info->CURRENTPOS;
     int movelen = movegen(board, list, color, incheck);
-    movescore(board, movelst, key, list, depth, color, type, movelen, 0, thread_info, entry);
+    movescore(board, movelst, key, list, depth, color, type, movelen, 0, thread_info, entry, true);
     bool raisedalpha = false;
     if (depth == 0)
     {


### PR DESCRIPTION
ELO   | 2.00 +- 1.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 93776 W: 24729 L: 24189 D: 44858
https://chess.swehosting.se/test/4789/