### PR TITLE
set ttmove in entry to first legal move if none were searched

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -121,7 +121,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     struct list list[LISTSIZE];
     int listlen = movegen(board, list, color, incheck);
 
-    movescore(board, movelst, key, list, 99, color, type, listlen, (!incheck && stand_pat + 60 < alpha ? ((alpha - stand_pat - 60) / 2) : -108), thread_info, entry, incheck);
+    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha ? 1 : -108), thread_info, entry, incheck);
     // score the moves
 
     struct move bestmove = nullmove;
@@ -132,7 +132,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     {
         selectionsort(list, i, listlen);
 
-        if (legals)
+        if (!incheck)
         {
             if (list[i].eval < 1000200) // Break if we have moved beyond searching winning captures and we are not in check (if we are then we search all moves)
             {
@@ -140,6 +140,8 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
             }
         }
         int piecetype = board->board[list[i].move.move >> 8] - 2;
+
+
         struct board_info board2 = *board;
 
         if (move(&board2, list[i].move, color, thread_info))
@@ -147,8 +149,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
             i++;
             continue;
         }
-
-        if (legals == 0){
+        if (!legals){
             bestmove = list[i].move;
         }
         legals++;

--- a/src/search.h
+++ b/src/search.h
@@ -121,7 +121,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     struct list list[LISTSIZE];
     int listlen = movegen(board, list, color, incheck);
 
-    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha && !incheck ? 1 : -108), thread_info, entry, incheck);
+    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha ? 1 : -108), thread_info, entry, incheck);
     // score the moves
 
     struct move bestmove = nullmove;
@@ -398,7 +398,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
     int i = 0;
     unsigned long long int original_pos = thread_info->CURRENTPOS;
     int movelen = movegen(board, list, color, incheck);
-    movescore(board, movelst, key, list, depth, color, type, movelen, 0, thread_info, entry, true);
+    movescore(board, movelst, key, list, depth, color, type, movelen, -108, thread_info, entry, true);
     bool raisedalpha = false;
     if (depth == 0)
     {

--- a/src/search.h
+++ b/src/search.h
@@ -121,7 +121,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     struct list list[LISTSIZE];
     int listlen = movegen(board, list, color, incheck);
 
-    movescore(board, movelst, key, list, 99, color, type, listlen, (!incheck && stand_pat + 60 < alpha ? (alpha - stand_pat - 60) : -108), thread_info, entry, incheck);
+    movescore(board, movelst, key, list, 99, color, type, listlen, (!incheck && stand_pat + 60 < alpha ? ((alpha - stand_pat - 60) / 2) : -108), thread_info, entry, incheck);
     // score the moves
 
     struct move bestmove = nullmove;
@@ -132,7 +132,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     {
         selectionsort(list, i, listlen);
 
-        if (!incheck)
+        if (legals)
         {
             if (list[i].eval < 1000200) // Break if we have moved beyond searching winning captures and we are not in check (if we are then we search all moves)
             {
@@ -140,14 +140,16 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
             }
         }
         int piecetype = board->board[list[i].move.move >> 8] - 2;
-
-
         struct board_info board2 = *board;
 
         if (move(&board2, list[i].move, color, thread_info))
         {
             i++;
             continue;
+        }
+
+        if (legals == 0){
+            bestmove = list[i].move;
         }
         legals++;
         move_add(board, movelst, key, list[i].move, color, (list[i].move.flags == 0xC || board->board[list[i].move.move & 0xFF]), thread_info, piecetype);

--- a/src/search.h
+++ b/src/search.h
@@ -121,7 +121,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     struct list list[LISTSIZE];
     int listlen = movegen(board, list, color, incheck);
 
-    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha ? 1 : -108), thread_info, entry, incheck);
+    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha ? (alpha - stand_pat - 60) : -108), thread_info, entry, incheck);
     // score the moves
 
     struct move bestmove = nullmove;
@@ -398,7 +398,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key, int 
     int i = 0;
     unsigned long long int original_pos = thread_info->CURRENTPOS;
     int movelen = movegen(board, list, color, incheck);
-    movescore(board, movelst, key, list, depth, color, type, movelen, -108, thread_info, entry, true);
+    movescore(board, movelst, key, list, depth, color, type, movelen, 0, thread_info, entry, true);
     bool raisedalpha = false;
     if (depth == 0)
     {

--- a/src/search.h
+++ b/src/search.h
@@ -121,7 +121,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     struct list list[LISTSIZE];
     int listlen = movegen(board, list, color, incheck);
 
-    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha ? 1 : -108), thread_info, entry, incheck);
+    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha && !incheck ? 1 : 0), thread_info, entry, incheck);
     // score the moves
 
     struct move bestmove = nullmove;

--- a/src/search.h
+++ b/src/search.h
@@ -121,7 +121,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     struct list list[LISTSIZE];
     int listlen = movegen(board, list, color, incheck);
 
-    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha ? (alpha - stand_pat - 60) : -108), thread_info, entry, incheck);
+    movescore(board, movelst, key, list, 99, color, type, listlen, (!incheck && stand_pat + 60 < alpha ? (alpha - stand_pat - 60) : -108), thread_info, entry, incheck);
     // score the moves
 
     struct move bestmove = nullmove;

--- a/src/search.h
+++ b/src/search.h
@@ -121,7 +121,7 @@ int quiesce(struct board_info *board, struct movelist *movelst, int *key, int al
     struct list list[LISTSIZE];
     int listlen = movegen(board, list, color, incheck);
 
-    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha && !incheck ? 1 : 0), thread_info, entry, incheck);
+    movescore(board, movelst, key, list, 99, color, type, listlen, (stand_pat + 60 < alpha && !incheck ? 1 : -108), thread_info, entry, incheck);
     // score the moves
 
     struct move bestmove = nullmove;


### PR DESCRIPTION
ELO   | 0.37 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
GAMES | N: 20848 W: 5380 L: 5358 D: 10110
https://chess.swehosting.se/test/4968/