### PR TITLE
fix cutnode impl

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -582,7 +582,6 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key,
 
     else {
       fullsearch = (!ispv) || betacount;
-      do_cutnode = true;
     }
 
     // If a search at reduced depth fails high, search at normal depth with
@@ -591,7 +590,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key,
     if (fullsearch) {
       list[i].eval =
           -alphabeta(&board2, movelst, key, -alpha - 1, -alpha, newdepth - 1,
-                     depth + 1, color ^ 1, do_cutnode ? true : !cutnode,
+                     depth + 1, color ^ 1, !cutnode,
                      ischeck, nullmove, thread_info);
       if (abs(list[i].eval) == TIMEOUT) {
         unmake(movelst, key, thread_info, original_pos);

--- a/src/search.h
+++ b/src/search.h
@@ -556,9 +556,7 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key,
       if (list[i].eval < 100000 && list[i].eval > -100000) {
         R -= std::clamp(list[i].eval / 8096, -2, 2);
       }
-      if (cutnode) {
-        R++;
-      }
+      R += cutnode*2;
       R = MAX(R, 1); // make sure the reduction doesn't go negative!
 
       if (newdepth - R < 1 && R > 1) {


### PR DESCRIPTION
After refactoring, I noticed that I was calling search with cutnode = true in one branch where it should be !cutnode.
Increased cutnode reduction to compensate.

ELO   | 3.25 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES | N: 37008 W: 9526 L: 9180 D: 18302
https://chess.swehosting.se/test/5348/

Bench: 19932583