### PR TITLE
drop into qsearch before checking the tt and such

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -215,6 +215,22 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key,
     info.depth = depthleft;
   }
 
+   if (depthleft <= 0 ||
+      depth >= 99) // if we're too deep drop into qsearch, adjusting based on
+                   // depth if we get a mate score.
+  {
+    int b = quiesce(board, movelst, key, alpha, beta, depth, MaxQsearchDepth, color, incheck,
+                    thread_info);
+    if (b == -100000) {
+      b += depth;
+    }
+    if (b == 100000) {
+      b -= depth;
+    }
+    return b;
+  }
+  
+
   thread_info->nodes++;
   if (thread_info->id == 0) {
     nodes++;
@@ -297,20 +313,6 @@ int alphabeta(struct board_info *board, struct movelist *movelst, int *key,
     }
   }
 
-  if (depthleft <= 0 ||
-      depth >= 99) // if we're too deep drop into qsearch, adjusting based on
-                   // depth if we get a mate score.
-  {
-    int b = quiesce(board, movelst, key, alpha, beta, depth, MaxQsearchDepth, color, incheck,
-                    thread_info);
-    if (b == -100000) {
-      b += depth;
-    }
-    if (b == 100000) {
-      b -= depth;
-    }
-    return b;
-  }
   if (incheck) // we cannot evaluate the position when in check, because there
                // may be no good move to get out. Otherwise, the evaluation of a
                // position is very useful for pruning.

--- a/src/simd.h
+++ b/src/simd.h
@@ -11,8 +11,12 @@ namespace SIMD {
         NEON,
         AUTO
     };
-
-#if defined(__AVX2__)
+#if defined(__AVX512F__)
+    #include <immintrin.h>
+    constexpr Arch ARCH = Arch::AVX2;
+    constexpr size_t REGISTER_SIZE = 32
+    ;     
+#elif defined(__AVX2__)
     #include <immintrin.h>
     constexpr Arch ARCH = Arch::AVX2;
     constexpr size_t REGISTER_SIZE = 16;
@@ -30,7 +34,9 @@ namespace SIMD {
 
     auto inline int16_load(auto data) {
 
-#if defined(__AVX2__)
+#if defined(__AVX512F__)
+        return _mm512_loadu_si512(reinterpret_cast<const __m512i*>(data));
+#elif defined(__AVX2__)
         return _mm256_loadu_si256(reinterpret_cast<const __m256i*>(data));
 #elif defined(__ARM_NEON__)
         return vld1q_s16(data);
@@ -41,9 +47,9 @@ namespace SIMD {
     }
 
     auto inline get_int16_vec(auto data) {
-
-#if defined(__AVX2__)
-
+#if defined(__AVX512F__)
+        return _mm512_set1_epi16(data);
+#elif defined(__AVX2__)
         return _mm256_set1_epi16(data);
 #elif defined(__ARM_NEON__)
         return vdupq_n_s16(data);
@@ -54,8 +60,11 @@ namespace SIMD {
     }
 
     auto inline vec_int16_clamp(auto vec, auto min_vec, auto max_vec) {
-
-#if defined(__AVX2__)
+#if defined(__AXV512F__)
+        vec = _mm512_max_epi16(vec, min_vec);
+        vec = _mm512_min_epi16(vec, max_vec);
+        return vec;
+#elif defined(__AVX2__)
         vec = _mm256_max_epi16(vec, min_vec);
         vec = _mm256_min_epi16(vec, max_vec);
         return vec;
@@ -71,8 +80,9 @@ namespace SIMD {
     }
 
     auto inline vec_int16_multiply(auto vec1, auto vec2) {
-
-#if defined(__AVX2__)
+#if defined(__AVX512F__)
+	return _mm512_mullo_epi16(vec1, vec2);
+#elif defined(__AVX2__)
         return _mm256_mullo_epi16(vec1, vec2);
 #elif defined(__ARM_NEON__)
         return vmulq_s16(vec1, vec2);
@@ -83,8 +93,9 @@ namespace SIMD {
     }
 
     auto inline vec_int32_zero() {
-
-#if defined(__AVX2__)
+#if defined(__AVX512F__)
+	return _mm512_setzero_si512();
+#elif defined(__AVX2__)
         return _mm256_setzero_si256();
 #elif defined(__ARM_NEON__)
         return vdupq_n_s32(0);
@@ -94,8 +105,9 @@ namespace SIMD {
     }
 
     auto inline vec_int32_add(auto vec1, auto vec2) {
-
-#if defined(__AVX2__)
+#if defined(__AVX512F__)
+	return _mm512_add_epi32(vec1, vec2);
+#elif defined(__AVX2__)
         return _mm256_add_epi32(vec1, vec2);
 #elif defined(__ARM_NEON__)
         return vaddq_s32(vec1, vec2);
@@ -105,8 +117,9 @@ namespace SIMD {
     }
 
     auto inline vec_int16_madd_int32(auto vec1, auto vec2) {
-
-#if defined(__AVX2__)
+#if defined(__AVX512F__)
+	return _mm512_madd_epi16(vec1, vec2);
+#elif defined(__AVX2__)
         return _mm256_madd_epi16(vec1, vec2);
 #elif defined(__ARM_NEON__)
         int32x4_t low_product  = vmull_s16(vget_low_s16 (vec1), vget_low_s16 (vec2));
@@ -120,8 +133,19 @@ namespace SIMD {
     }
 
     auto inline vec_int32_hadd(auto vec) {
+#if defined(__AVX512F__)
+	auto low   = _mm512_castsi512_si256(vec);
+	auto high  = _mm512_extracti32x8_epi32(vec, 1);
+	auto sum8 = _mm256_add_epi32(low, high);
+	auto sum4 = _mm256_hadd_epi32(sum8, sum8);
+	auto sum2 = _mm256_hadd_epi32(sum4, sum4);
 
-#if defined(__AVX2__)
+	auto lower_number = _mm256_castsi256_si128(sum2);
+	auto higher_number =  _mm256_extractf128_si256(sum2, 1);
+	auto result = _mm_add_epi32(lower_number, higher_number);
+	return _mm_extract_epi32(result, 0);
+
+#elif defined(__AVX2__)
         auto sum_into_4 = _mm256_hadd_epi32(vec, vec);
         auto sum_into_2 = _mm256_hadd_epi32(sum_into_4, sum_into_4);
 


### PR DESCRIPTION
Bench: 12765566

ELO   | 1.90 +- 4.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
GAMES | N: 12448 W: 3193 L: 3125 D: 6130
https://chess.swehosting.se/test/5397/

This also changes how nodes are counted, resulting in a likely NPS drop. Rebenches should be done if possible